### PR TITLE
Add publisher option to rosboard

### DIFF
--- a/packages/studio-base/src/players/RosboardPlayer.ts
+++ b/packages/studio-base/src/players/RosboardPlayer.ts
@@ -17,7 +17,7 @@ import { v4 as uuidv4 } from "uuid";
 import { debouncePromise } from "@foxglove/den/async";
 // import { filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
-import roslib from "@foxglove/roslibjs";
+// import roslib from "@foxglove/roslibjs";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { MessageReader as ROS1MessageReader } from "@foxglove/rosmsg-serialization";
 import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";
@@ -41,7 +41,7 @@ import {
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { bagConnectionsToDatatypes } from "@foxglove/studio-base/util/bagConnectionsHelper";
 
-import RosboardClient from "./rosboardClient";
+import RosboardClient, { PubTopic } from "./rosboardClient";
 
 const log = Log.getLogger(__dirname);
 
@@ -123,7 +123,7 @@ export default class RosboardPlayer implements Player {
   #parsedMessages: MessageEvent[] = []; // Queue of messages that we'll send in next _emitState() call.
   #requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
   // active publishers for the current connection
-  #topicPublishers = new Map<string, roslib.Topic>();
+  #topicPublishers = new Map<string, PubTopic>();
   // which topics we want to advertise to other nodes
   #advertisements: AdvertiseOptions[] = [];
   #parsedTopics = new Set<string>();
@@ -723,17 +723,16 @@ export default class RosboardPlayer implements Player {
   }
 
   public setPublishers(publishers: AdvertiseOptions[]): void {
-    publishers;
+    // console.log("setPublishers: Setting publishers");
+    // console.log(publishers);
     // Since `setPublishers` is rarely called, we can get away with just throwing away the old
     // Roslib.Topic objects and creating new ones.
-    /* TODO
     for (const publisher of this.#topicPublishers.values()) {
       publisher.unadvertise();
     }
     this.#topicPublishers.clear();
     this.#advertisements = publishers;
     this.#setupPublishers();
-    */
     return;
   }
 
@@ -750,9 +749,9 @@ export default class RosboardPlayer implements Player {
   }
 
   public publish({ topic, msg }: PublishPayload): void {
-    topic;
-    msg;
-    /* TODO
+    // console.log("publish: Publishing message");
+    // console.log(topic, msg);
+
     const publisher = this.#topicPublishers.get(topic);
     if (!publisher) {
       if (this.#advertisements.some((opts) => opts.topic === topic)) {
@@ -764,7 +763,7 @@ export default class RosboardPlayer implements Player {
       );
     }
     publisher.publish(msg);
-    */
+
     return;
   }
 
@@ -848,7 +847,6 @@ export default class RosboardPlayer implements Player {
   }
 
   #setupPublishers(): void {
-    /* TODO
     // This function will be called again once a connection is established
     if (!this.#rosClient) {
       return;
@@ -857,18 +855,15 @@ export default class RosboardPlayer implements Player {
     if (this.#advertisements.length <= 0) {
       return;
     }
+    // console.log("#setupPublishers: Setting up publishers");
+    // console.log(this.#advertisements);
 
     for (const { topic, schemaName: datatype } of this.#advertisements) {
-      const roslibTopic = new roslib.Topic({
-        ros: this.#rosClient,
-        name: topic,
-        messageType: datatype,
-        queue_size: 0,
-      });
+      const roslibTopic = new PubTopic(this.#rosClient, topic, datatype, 0);
       this.#topicPublishers.set(topic, roslibTopic);
       roslibTopic.advertise();
     }
-    */
+
     return;
   }
 

--- a/packages/studio-base/src/players/rosboardClient.ts
+++ b/packages/studio-base/src/players/rosboardClient.ts
@@ -1,242 +1,257 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 interface Topic {
-	[name: string]: string;
+  [name: string]: string;
 }
 
 interface TypeIndex {
-    [type: string]: string | undefined;
+  [type: string]: string | undefined;
 }
 
 interface SubscribePayload {
-	topicName: string;
-	maxUpdateRate: number;
+  topicName: string;
+  maxUpdateRate: number;
 }
 
 interface UnsubscribePayload {
-	topicName: string;
+  topicName: string;
 }
 
 interface MessagePayload {
-	[key: string]: any;
+  [key: string]: any;
 }
 
 type MessageCallback = (message: MessagePayload) => void;
 type EventCallback = () => void;
 
+// export default class Topic {
+//   rosboardClient: RosboardClient;
+//   name: string;
+//   messageType: string;
+//   queueSize: number;
+// }
+
 export default class RosboardClient {
-	ws?: WebSocket;
-	hostname: string = '';
-	version: string = '';
-	closed: boolean = false;
-	url: string;
-	private _availableTopics: Topic = {};
-	private _topicsFull: TypeIndex = {};
-	private _topicsFullRequested: boolean = false;
-	sequenceNumber: number | null = null;
-	connectionCallbacks: EventCallback[] = [];
-	errorCallback?: (error: Error) => void;
-	closeCallback?: () => void;
-	subscribedTopics: string[] = [];
-	topicCallbacks: { [topicName: string]: MessageCallback } = {};
+  ws?: WebSocket;
+  hostname: string = "";
+  version: string = "";
+  closed: boolean = false;
+  url: string;
+  private _availableTopics: Topic = {};
+  private _topicsFull: TypeIndex = {};
+  private _topicsFullRequested: boolean = false;
+  sequenceNumber: number | null = null;
+  connectionCallbacks: EventCallback[] = [];
+  errorCallback?: (error: Error) => void;
+  closeCallback?: () => void;
+  subscribedTopics: string[] = [];
+  topicCallbacks: { [topicName: string]: MessageCallback } = {};
 
-	public constructor({
-		url,
-	}: {
-		url: string;
-	}) {
-		this.url = url;
-		this.openConnection();
-	}
+  public constructor({ url }: { url: string }) {
+    this.url = url;
+    this.openConnection();
+  }
 
-	openConnection = (): void => {
-		if (this.ws != undefined) {
-			throw new Error(`Attempted to open a second WebSocket Connection`);
-		}
+  openConnection = (): void => {
+    if (this.ws != undefined) {
+      throw new Error(`Attempted to open a second WebSocket Connection`);
+    }
 
-		const ws = new WebSocket(this.url);
+    const ws = new WebSocket(this.url);
 
-		ws.addEventListener('open', () => {
-			this.ws = ws;
-			this.connectionCallbacks.forEach(callback => callback());
-		});
+    ws.addEventListener("open", () => {
+      this.ws = ws;
+      this.connectionCallbacks.forEach((callback) => {
+        callback();
+      });
+    });
 
-		ws.addEventListener('error', (event) => {
-			console.error('WebSocket error:', event);
-			const error = event instanceof ErrorEvent ? event.error : new Error('WebSocket error');
-			if (this.errorCallback) {
-				this.errorCallback(error);
-			}
-		});
+    ws.addEventListener("error", (event) => {
+      console.error("WebSocket error:", event);
+      const error = event instanceof ErrorEvent ? event.error : new Error("WebSocket error");
+      if (this.errorCallback) {
+        this.errorCallback(error);
+      }
+    });
 
-		ws.addEventListener('close', () => {
-			this.ws = undefined;
-			this.closed = true;
-			if (this.closeCallback) {
-				this.closeCallback();
-			}
-		});
+    ws.addEventListener("close", () => {
+      this.ws = undefined;
+      this.closed = true;
+      if (this.closeCallback) {
+        this.closeCallback();
+      }
+    });
 
-		ws.addEventListener('message', async (event) => {
+    ws.addEventListener("message", async (event) => {
+      try {
+        let data: [string, any];
+        if (typeof event.data === "string") {
+          data = JSON.parse(event.data);
+        } else if (event.data instanceof Blob) {
+          const result = await new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
 
-			try {
-				let data: [string, any];
-				if (typeof event.data === 'string') {
-					data = JSON.parse(event.data as string);
-				} else if (event.data instanceof Blob) {
-					const result = await new Promise<string>((resolve, reject) => {
-						const reader = new FileReader();
+            reader.onload = () => {
+              if (reader.result) {
+                resolve(reader.result as string);
+              } else {
+                reject(new Error("Reader result is empty"));
+              }
+            };
 
-						reader.onload = () => {
-							if (reader.result) {
-								resolve(reader.result as string);
-							} else {
-								reject(new Error("Reader result is empty"));
-							}
-						};
+            reader.onerror = () => {
+              reject(reader.error);
+            };
 
-						reader.onerror = () => {
-							reject(reader.error);
-						};
+            reader.readAsText(event.data as Blob);
+          });
 
-						reader.readAsText(event.data as Blob);
-					});
+          data = JSON.parse(result) as [string, any];
+        } else {
+          data = ["z", "invalid"];
+          //console.log("Invalid input");
+          //console.log(typeof(data));
+        }
+        const [type, payload] = data;
 
-					data = JSON.parse(result) as [string, any];
-				} else {
-					data = ["z", "invalid"];
-					//console.log("Invalid input");
-					//console.log(typeof(data));
-				}
-				const [type, payload] = data;
+        if (type === "y" && typeof payload === "object") {
+          this.hostname = payload.hostname;
+          this.version = payload.version;
+        } else if (type === "t" && typeof payload === "object") {
+          // Update availableTopics directly with the new payload
+          this._availableTopics = payload;
+          //console.log('Updated Available Topics:', this._availableTopics);
+        } else if (type === "f" && typeof payload === "object") {
+          // Update availableTopics directly with the new payload
+          const typedefs: TypeIndex = {};
+          Object.keys(payload).forEach((k) => {
+            typedefs[payload[k].type] = payload[k].typedef;
+          });
+          this._topicsFull = typedefs;
+          this._topicsFullRequested = false;
+        } else if (
+          type === "m" &&
+          typeof payload === "object" &&
+          payload._topic_name &&
+          this.subscribedTopics.includes(payload._topic_name)
+        ) {
+          // Message received for a subscribed topic
+          const topicName = payload._topic_name;
+          if (this.topicCallbacks[topicName]) {
+            // Execute the callback function for the topic
+            const callback = this.topicCallbacks[topicName];
+            if (typeof callback == "function") {
+              callback(payload);
+            }
+          }
+        } else if (type === "p" && typeof payload === "object" && typeof payload.s === "number") {
+          // Respond with a message of type 'q' containing the current timestamp and matching sequence number
+          const sequenceNumber = payload.s;
+          const timestamp = Date.now();
+          const response = JSON.stringify(["q", { s: sequenceNumber, t: timestamp }]);
+          if (this.ws && response) {
+            this.ws.send(response);
+            //console.log('Sent response:', response);
+          }
+        }
+      } catch (error) {
+        console.error("Error parsing message:", error);
+      }
+    });
+  };
 
-				if (type === 'y' && typeof payload === 'object') {
-					this.hostname = payload.hostname;
-					this.version = payload.version;
+  on(
+    event: "connection" | "error" | "close",
+    callback: EventCallback | ((error: Error) => void) | (() => void),
+  ) {
+    if (event === "connection") {
+      this.connectionCallbacks.push(callback as EventCallback);
+    } else if (event === "error") {
+      this.errorCallback = callback as (error: Error) => void;
+    } else if (event === "close") {
+      this.closeCallback = callback as () => void;
+    }
+  }
 
-				} else if (type === 't' && typeof payload === 'object') {
-					// Update availableTopics directly with the new payload
-					this._availableTopics = payload;
-					//console.log('Updated Available Topics:', this._availableTopics);
-				} else if (type === 'f' && typeof payload === 'object') {
-					// Update availableTopics directly with the new payload
-					let typedefs: TypeIndex = {};
-					Object.keys(payload).forEach((k) => {
-						typedefs[payload[k].type] = payload[k].typedef;
-					})
-					this._topicsFull = typedefs;
-					this._topicsFullRequested = false;
-				} else if (type === 'm' && typeof payload === 'object' && payload._topic_name && this.subscribedTopics.includes(payload._topic_name)) {
-					// Message received for a subscribed topic
-					const topicName = payload._topic_name;
-					if (this.topicCallbacks[topicName]) {
-						// Execute the callback function for the topic
-						const callback = this.topicCallbacks[topicName];
-						if (typeof callback == 'function') {
-							callback(payload);
-						}
-					}
-				} else if (type === 'p' && typeof payload === 'object' && typeof payload.s === 'number') {
-					// Respond with a message of type 'q' containing the current timestamp and matching sequence number
-					const sequenceNumber = payload.s;
-					const timestamp = Date.now();
-					const response = JSON.stringify(['q', { s: sequenceNumber, t: timestamp }]);
-					if (this.ws && response) {
-						this.ws.send(response);
-						//console.log('Sent response:', response);
-					}
-				} 
-			} catch (error) {
-				console.error('Error parsing message:', error);
-			}
-		});
-	}
+  get availableTopics(): Topic {
+    return this._availableTopics;
+  }
 
-	on(event: 'connection' | 'error' | 'close', callback: EventCallback | ((error: Error) => void) | (() => void)) {
-		if (event === 'connection') {
-			this.connectionCallbacks.push(callback as EventCallback);
-		} else if (event === 'error') {
-			this.errorCallback = callback as (error: Error) => void;
-		} else if (event === 'close') {
-			this.closeCallback = callback as () => void;
-		}
-	}
+  get topicsFull(): TypeIndex {
+    return this._topicsFull;
+  }
 
-	get availableTopics(): Topic {
-		return this._availableTopics;
-	}
+  requestTopicsFull(): void {
+    if (this._topicsFullRequested) {
+      return;
+    }
+    const message = JSON.stringify(["f"]);
+    if (message !== undefined) {
+      this.send(message);
+      this._topicsFullRequested = true;
+    } else {
+      console.error("Message is undefined. Cannot send.");
+    }
+  }
 
-	get topicsFull(): TypeIndex {
-		return this._topicsFull;
-	}
+  subscribe(topicName: string, maxUpdateRate: number): void {
+    const payload: SubscribePayload = {
+      topicName,
+      maxUpdateRate,
+    };
+    const message = JSON.stringify(["s", payload]);
+    //console.log(message);
+    //console.log ("Subscribing to ", topicName);
+    if (message !== undefined) {
+      this.send(message);
+    } else {
+      console.error("Message is undefined. Cannot send.");
+    }
+    this.subscribedTopics.push(topicName);
+  }
 
-	requestTopicsFull(): void {
-		if (this._topicsFullRequested) {
-			return;
-		}
-		const message = JSON.stringify(['f']);
-		if (message !== undefined) {
-			this.send(message);
-			this._topicsFullRequested = true;
-		} else {
-			console.error("Message is undefined. Cannot send.");
-		}
-	}
+  unsubscribe(topicName: string): void {
+    const payload: UnsubscribePayload = {
+      topicName,
+    };
+    const message = JSON.stringify(["u", payload]);
+    //console.log ("Un-Subscribing to ", topicName);
+    if (message !== undefined) {
+      this.send(message);
+    } else {
+      console.error("Message is undefined. Cannot send.");
+    }
+    const index = this.subscribedTopics.indexOf(topicName);
+    if (index !== -1) {
+      this.subscribedTopics.splice(index, 1);
+    }
+  }
 
-	subscribe(topicName: string, maxUpdateRate: number): void {
-		const payload: SubscribePayload = {
-			topicName,
-			maxUpdateRate
-		};
-		const message = JSON.stringify(['s', payload]);
-		//console.log(message);
-		//console.log ("Subscribing to ", topicName);
-		if (message !== undefined) {
-			this.send(message);
-		} else {
-			console.error("Message is undefined. Cannot send.");
-		}
-		this.subscribedTopics.push(topicName);
-	}
+  addTopicCallback(topicName: string, callback: MessageCallback): void {
+    this.topicCallbacks[topicName] = callback;
+    // Subscribe to the topic when adding the callback
+    this.subscribe(topicName, 24);
+  }
 
-	unsubscribe(topicName: string): void {
-		const payload: UnsubscribePayload = {
-			topicName
-		};
-		const message = JSON.stringify(['u', payload]);
-		//console.log ("Un-Subscribing to ", topicName);
-		if (message !== undefined) {
-			this.send(message);
-		} else {
-			console.error("Message is undefined. Cannot send.");
-		}
-		const index = this.subscribedTopics.indexOf(topicName);
-		if (index !== -1) {
-			this.subscribedTopics.splice(index, 1);
-		}
-	}
+  private send(message: string): void {
+    if (this.ws) {
+      this.ws.send(message);
+      //console.log('Sent message:', message);
+    } else {
+      console.error("WebSocket connection is not established");
+    }
+  }
 
-	addTopicCallback(topicName: string, callback: MessageCallback): void {
-		this.topicCallbacks[topicName] = callback;
-		// Subscribe to the topic when adding the callback
-		this.subscribe(topicName, 24);
-	}
-
-	private send(message: string): void {
-		if (this.ws) {
-			this.ws.send(message);
-			//console.log('Sent message:', message);
-		} else {
-			console.error('WebSocket connection is not established');
-		}
-	}
-
-	close(): void {
-		if (this.ws) {
-			this.ws.close();
-			this.ws = undefined;
-			this.closed = true;
-			//console.log('WebSocket connection closed');
-		} else {
-			console.warn('WebSocket connection is already closed');
-		}
-	}
+  close(): void {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = undefined;
+      this.closed = true;
+      //console.log('WebSocket connection closed');
+    } else {
+      console.warn("WebSocket connection is already closed");
+    }
+  }
 }

--- a/packages/studio-base/src/players/rosboardClient.ts
+++ b/packages/studio-base/src/players/rosboardClient.ts
@@ -26,12 +26,88 @@ interface MessagePayload {
 type MessageCallback = (message: MessagePayload) => void;
 type EventCallback = () => void;
 
-// export default class Topic {
-//   rosboardClient: RosboardClient;
-//   name: string;
-//   messageType: string;
-//   queueSize: number;
-// }
+// Replaces any key named "nsec" with "nanosec" in the object
+function renameNsecToNanosec(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => renameNsecToNanosec(item));
+  } else if (obj !== null && typeof obj === "object") {
+    const newObj: any = {};
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        const newKey = key === "nsec" ? "nanosec" : key;
+        newObj[newKey] = renameNsecToNanosec(obj[key]);
+      }
+    }
+    return newObj;
+  }
+  return obj;
+}
+
+// Custom replacer function to convert 0 to 0.0 for specific fields
+function convertZerosToFixedReplacer(fields: string[]) {
+  return function (key: string, value: any): any {
+    if (fields.includes(key) && value === 0) {
+      return parseFloat(value).toFixed(1); // Ensure that 0 is represented as 0.0, this returns a string
+    }
+    return value;
+  };
+}
+
+export class PubTopic {
+  rosClient: RosboardClient;
+  name: string;
+  messageType: string;
+  queueSize: number;
+
+  constructor(rosClient: RosboardClient, name: string, messageType: string, queueSize: number) {
+    this.rosClient = rosClient;
+    this.name = name;
+    this.messageType = messageType;
+    this.queueSize = queueSize;
+  }
+
+  unadvertise(): void {
+    // Send message to destroy publisher in server. Message is expected to be: ["n", {topicName: xxxx}]
+    const message = JSON.stringify(["n", { topicName: this.name }]);
+    if (message !== undefined) {
+      this.rosClient.send(message);
+    } else {
+      console.error("Message is undefined. Cannot send.");
+    }
+  }
+
+  // Just for compatibility with the roslib version
+  // In rosboard we don't need to advertise the topic, it is done automatically when
+  // we send a message for the first time in the rosboard server
+  advertise(): void {}
+
+  publish(msg: MessagePayload): void {
+    // Rosboard expects headers to have nsec named nanosec, but foxglove uses nsec
+    msg = renameNsecToNanosec(msg);
+    // rosboard expects a message like this: ["m", {message dictionary}]
+    // and message dictionary is in the form of {_topic_name: topic, _topic_type: type, ...payload}
+    const payload = {
+      _topic_name: this.name,
+      _topic_type: this.messageType,
+      ...msg,
+    };
+
+    // List of field names to check for 0 so it can be converted to 0.0
+    // This is necessary because expected values are floats and if sent just as 0
+    // rosboard dies with an error. Hacky solution but it works for now.
+    const fieldsToCast = ["x", "y", "z", "w"];
+    // Stringify the payload with custom replacer to ensure 0 is represented as "0.0"
+    let jsonString = JSON.stringify(["m", payload], convertZerosToFixedReplacer(fieldsToCast));
+
+    if (jsonString !== undefined) {
+      // because 0s were converted to "0.0" (string) we need to convert them back to 0.0 (remove quotes)
+      jsonString = jsonString.replace(/"0.0"/g, "0.0");
+      this.rosClient.send(jsonString);
+    } else {
+      console.error("Message is undefined. Cannot send.");
+    }
+  }
+}
 
 export default class RosboardClient {
   ws?: WebSocket;
@@ -235,7 +311,7 @@ export default class RosboardClient {
     this.subscribe(topicName, 24);
   }
 
-  private send(message: string): void {
+  send(message: string): void {
     if (this.ws) {
       this.ws.send(message);
       //console.log('Sent message:', message);

--- a/packages/studio-base/src/players/rosboardClient.ts
+++ b/packages/studio-base/src/players/rosboardClient.ts
@@ -43,16 +43,6 @@ function renameNsecToNanosec(obj: any): any {
   return obj;
 }
 
-// Custom replacer function to convert 0 to 0.0 for specific fields
-function convertZerosToFixedReplacer(fields: string[]) {
-  return function (key: string, value: any): any {
-    if (fields.includes(key) && value === 0) {
-      return parseFloat(value).toFixed(1); // Ensure that 0 is represented as 0.0, this returns a string
-    }
-    return value;
-  };
-}
-
 export class PubTopic {
   rosClient: RosboardClient;
   name: string;
@@ -92,16 +82,9 @@ export class PubTopic {
       ...msg,
     };
 
-    // List of field names to check for 0 so it can be converted to 0.0
-    // This is necessary because expected values are floats and if sent just as 0
-    // rosboard dies with an error. Hacky solution but it works for now.
-    const fieldsToCast = ["x", "y", "z", "w"];
-    // Stringify the payload with custom replacer to ensure 0 is represented as "0.0"
-    let jsonString = JSON.stringify(["m", payload], convertZerosToFixedReplacer(fieldsToCast));
+    const jsonString = JSON.stringify(["m", payload]);
 
     if (jsonString !== undefined) {
-      // because 0s were converted to "0.0" (string) we need to convert them back to 0.0 (remove quotes)
-      jsonString = jsonString.replace(/"0.0"/g, "0.0");
       this.rosClient.send(jsonString);
     } else {
       console.error("Message is undefined. Cannot send.");


### PR DESCRIPTION
* Added the code to publish data to the rosboard server
* Tested only with simple messages that require no compression. Not supported other topics like images, laserscan, pointcloud etc.
* Rosboard dies if you send 0 in some fields that are expected to be float (like poses, point, etc). There is a hack to send the 0 as 0.0, but we had to hardcode the possible fields for that. Working well for default publisher foxglove supports (point, posestmped, posestampdewithcovariance). UPDATE: Now fixed directly in the server with https://github.com/kiwicampus/rospy_message_converter/pull/1