### PR TITLE
Add quaternion Euler plotting

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
@@ -18,6 +18,7 @@ import { MessageBlock, PlayerState } from "@foxglove/studio-base/players/types";
 import { Bounds } from "@foxglove/studio-base/types/Bounds";
 import delay from "@foxglove/studio-base/util/delay";
 import { getContrastColor, getLineColor } from "@foxglove/studio-base/util/plotColors";
+import { quatToEuler, isQuaternion } from "@foxglove/studio-base/util/quatToEuler";
 
 import { Dataset, InteractionEvent, Scale, UpdateAction } from "./ChartRenderer";
 import { OffscreenCanvasRenderer } from "./OffscreenCanvasRenderer";
@@ -151,7 +152,17 @@ export class PlotCoordinator extends EventEmitter<EventTypes> {
         }
         const items = simpleGetMessagePathDataItems(msgEvent, seriesItem.parsed);
         if (items.length > 0) {
-          this.#currentValuesByConfigIndex[seriesItem.configIndex] = items[items.length - 1];
+          let value: unknown = items[items.length - 1];
+          if (
+            (seriesItem.parsed.modifier === "roll" ||
+              seriesItem.parsed.modifier === "pitch" ||
+              seriesItem.parsed.modifier === "yaw") &&
+            isQuaternion(value)
+          ) {
+            const [r, p, y] = quatToEuler(value.x, value.y, value.z, value.w);
+            value = seriesItem.parsed.modifier === "roll" ? r : seriesItem.parsed.modifier === "pitch" ? p : y;
+          }
+          this.#currentValuesByConfigIndex[seriesItem.configIndex] = value;
           break;
         }
       }

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
@@ -25,6 +25,7 @@ import {
   Viewport,
 } from "./IDatasetsBuilder";
 import { getChartValue, isChartValue } from "../datum";
+import { quatToEuler, isQuaternion } from "@foxglove/studio-base/util/quatToEuler";
 import { MathFunction, mathFunctions } from "../mathFunctions";
 
 type CustomDatasetsSeriesItem = {
@@ -246,18 +247,34 @@ function readMessagePathItems(
 
     const items = simpleGetMessagePathDataItems(event, path);
     for (const item of items) {
-      if (!isChartValue(item)) {
-        continue;
+      let value: number | undefined;
+      let original: unknown = item;
+
+      if (path.modifier === "roll" || path.modifier === "pitch" || path.modifier === "yaw") {
+        if (isQuaternion(item)) {
+          const [r, p, y] = quatToEuler(item.x, item.y, item.z, item.w);
+          value = path.modifier === "roll" ? r : path.modifier === "pitch" ? p : y;
+        } else {
+          continue;
+        }
+      } else {
+        if (!isChartValue(item)) {
+          continue;
+        }
+        const chartValue = getChartValue(item);
+        if (chartValue == undefined) {
+          continue;
+        }
+        value = mathFunction ? mathFunction(chartValue) : chartValue;
       }
-      const chartValue = getChartValue(item);
-      if (chartValue == undefined) {
+
+      if (value == undefined) {
         continue;
       }
 
-      const mathModified = mathFunction ? mathFunction(chartValue) : chartValue;
       out.push({
-        value: mathModified,
-        originalValue: mathFunction ? mathModified : item,
+        value,
+        originalValue: path.modifier === "roll" || path.modifier === "pitch" || path.modifier === "yaw" ? value : mathFunction ? value : original,
         receiveTime: event.receiveTime,
       });
     }

--- a/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
@@ -21,6 +21,7 @@ import {
 import { Dataset } from "../ChartRenderer";
 import { getChartValue, isChartValue, Datum } from "../datum";
 import { mathFunctions } from "../mathFunctions";
+import { quatToEuler, isQuaternion } from "@foxglove/studio-base/util/quatToEuler";
 
 type DatumWithReceiveTime = Datum & {
   receiveTime: Time;
@@ -65,18 +66,30 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
 
       const items = simpleGetMessagePathDataItems(msgEvent, series.parsed);
       const pathItems = filterMap(items, (item, idx) => {
-        if (!isChartValue(item)) {
-          return;
+        let value: number | undefined;
+        if (series.parsed.modifier === "roll" || series.parsed.modifier === "pitch" || series.parsed.modifier === "yaw") {
+          if (isQuaternion(item)) {
+            const [r, p, y] = quatToEuler(item.x, item.y, item.z, item.w);
+            value = series.parsed.modifier === "roll" ? r : series.parsed.modifier === "pitch" ? p : y;
+          } else {
+            return undefined;
+          }
+        } else {
+          if (!isChartValue(item)) {
+            return undefined;
+          }
+          const chartValue = getChartValue(item);
+          if (chartValue == undefined) {
+            return undefined;
+          }
+          value = mathFn && chartValue != undefined ? mathFn(chartValue) : chartValue;
         }
 
-        const chartValue = getChartValue(item);
-        const mathModifiedValue =
-          mathFn && chartValue != undefined ? mathFn(chartValue) : undefined;
         return {
           x: idx,
-          y: chartValue == undefined ? NaN : mathModifiedValue ?? chartValue,
+          y: value!,
           receiveTime: msgEvent.receiveTime,
-          value: mathModifiedValue ?? item,
+          value,
         };
       });
 

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -27,6 +27,7 @@ import type {
 } from "./TimestampDatasetsBuilderImpl";
 import { getChartValue, isChartValue } from "../datum";
 import { MathFunction, mathFunctions } from "../mathFunctions";
+import { quatToEuler, isQuaternion } from "@foxglove/studio-base/util/quatToEuler";
 
 // If the datasets builder is garbage collected we also need to cleanup the worker
 // This registry ensures the worker is cleaned up when the builder is garbage collected
@@ -216,11 +217,29 @@ function readMessagePathItems(
 
     const items = simpleGetMessagePathDataItems(event, path);
     for (const item of items) {
-      if (!isChartValue(item)) {
-        continue;
+      let rawValue: unknown = item;
+      let yValue: number | undefined;
+
+      if (path.modifier === "roll" || path.modifier === "pitch" || path.modifier === "yaw") {
+        if (isQuaternion(item)) {
+          const [r, p, y] = quatToEuler(item.x, item.y, item.z, item.w);
+          const angle = path.modifier === "roll" ? r : path.modifier === "pitch" ? p : y;
+          yValue = angle;
+        } else {
+          continue;
+        }
+      } else {
+        if (!isChartValue(item)) {
+          continue;
+        }
+        const chartValue = getChartValue(item);
+        if (chartValue == undefined) {
+          continue;
+        }
+        yValue = mathFunction ? mathFunction(chartValue) : chartValue;
       }
-      const chartValue = getChartValue(item);
-      if (chartValue == undefined) {
+
+      if (yValue == undefined) {
         continue;
       }
 
@@ -231,13 +250,12 @@ function readMessagePathItems(
       }
 
       const xValue = toSec(subtractTime(timestamp, startTime));
-      const mathModified = mathFunction ? mathFunction(chartValue) : chartValue;
       out.push({
         x: xValue,
-        y: mathModified,
+        y: yValue!,
         receiveTime: event.receiveTime,
         headerStamp,
-        value: mathFunction ? mathModified : item,
+        value: path.modifier === "roll" || path.modifier === "pitch" || path.modifier === "yaw" ? yValue! : mathFunction ? yValue! : rawValue,
       });
     }
   }

--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -23,6 +23,7 @@ import {
 } from "@foxglove/studio-base/panels/StateTransitions/openSiblingStateTransitionsPanel";
 import { OpenSiblingPanel } from "@foxglove/studio-base/types/panels";
 import clipboard from "@foxglove/studio-base/util/clipboard";
+import { isQuaternion } from "@foxglove/studio-base/util/quatToEuler";
 
 import HighlightedValue from "./HighlightedValue";
 import { copyMessageReplacer } from "./copyMessageReplacer";
@@ -95,6 +96,15 @@ function Value(props: ValueProps): JSX.Element {
     [basePath, openSiblingPanel],
   );
 
+  const openPlotPanelMultiple = useCallback(
+    (pathSuffixes: string[]) => () => {
+      for (const suffix of pathSuffixes) {
+        openSiblingPlotPanel(openSiblingPanel, `${basePath}${suffix}`);
+      }
+    },
+    [basePath, openSiblingPanel],
+  );
+
   const openStateTransitionsPanel = useCallback(
     (pathSuffix: string) => () => {
       openSiblingStateTransitionsPanel(openSiblingPanel, `${basePath}${pathSuffix}`);
@@ -131,6 +141,14 @@ function Value(props: ValueProps): JSX.Element {
         onClick: () => {
           handleCopy(JSON.stringify(itemValue, copyMessageReplacer, 2) ?? "");
         },
+      });
+    }
+    if (isQuaternion(itemValue)) {
+      actions.push({
+        key: "euler",
+        tooltip: "Plot Euler angles",
+        icon: <LineChartIcon fontSize="inherit" />,
+        onClick: openPlotPanelMultiple([".@roll", ".@pitch", ".@yaw"]),
       });
     }
     if (valueAction != undefined) {
@@ -180,6 +198,7 @@ function Value(props: ValueProps): JSX.Element {
     itemValue,
     onFilter,
     openPlotPanel,
+    openPlotPanelMultiple,
     openStateTransitionsPanel,
     valueAction,
   ]);

--- a/packages/studio-base/src/util/quatToEuler.ts
+++ b/packages/studio-base/src/util/quatToEuler.ts
@@ -7,6 +7,22 @@ import * as THREE from "three";
 const tempQuaternion = new THREE.Quaternion();
 const tempEuler = new THREE.Euler();
 
+export function isQuaternion(value: unknown): value is {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+} {
+  return (
+    typeof value === "object" &&
+    value != undefined &&
+    typeof (value as any).x === "number" &&
+    typeof (value as any).y === "number" &&
+    typeof (value as any).z === "number" &&
+    typeof (value as any).w === "number"
+  );
+}
+
 /**
  * Convert a quaternion to roll-pitch-yaw Euler angles.
  * Returns angles in degrees using extrinsic ZYX (yaw-pitch-roll) convention,


### PR DESCRIPTION
## Summary
- support quaternion objects via `isQuaternion`
- compute Euler angles for quaternion time plots
- add menu option to plot Euler angles

## Testing
- `yarn test` *(fails: Syntax Error due to missing Git LFS objects)*

------
https://chatgpt.com/codex/tasks/task_e_688d11a6abf883258b66ada0661e8ba2